### PR TITLE
Make Linux build script more robust

### DIFF
--- a/crates/openconnect-sys/build/main.rs
+++ b/crates/openconnect-sys/build/main.rs
@@ -5,6 +5,7 @@ mod lib_prob;
 
 use lib_prob::*;
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 
 use crate::download_prebuilt::download_prebuilt_from_sourceforge;
@@ -27,8 +28,6 @@ fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let openconnect_src_dir = out_path.join("openconnect");
 
-    let current_dir = env::current_dir().unwrap();
-
     // statically link openconnect
     let openconnect_lib = openconnect_src_dir.join(".libs");
     let static_lib = openconnect_lib.join("libopenconnect.a");
@@ -37,14 +36,20 @@ fn main() {
         if use_prebuilt {
             download_prebuilt_from_sourceforge(out_path.clone());
         } else {
-            let script = current_dir.join("scripts/nix.sh");
-            let _ = std::process::Command::new("sh")
+            let script = manifest_dir.join("scripts/nix.sh");
+            let output = std::process::Command::new("sh")
                 .args([
                     script.to_str().unwrap(),
                     openconnect_src_dir.to_str().unwrap(),
                 ])
                 .output()
                 .expect("failed to execute process");
+            if !output.status.success() {
+                panic!(
+                    "failed to build bundled openconnect: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
         }
     }
 
@@ -69,10 +74,8 @@ fn main() {
         let wintun_dll_target = format!("{}/wintun.dll", target_path.to_string_lossy());
         std::fs::copy(wintun_dll_source, wintun_dll_target).unwrap();
 
-        try_pkg_config(vec!["libxml-2.0", "zlib", "liblz4", "iconv"]);
+        try_pkg_config(vec!["openssl", "libxml-2.0", "zlib", "liblz4", "iconv"]);
         println!("cargo:rustc-link-lib=static=intl");
-        println!("cargo:rustc-link-lib=static=crypto");
-        println!("cargo:rustc-link-lib=static=ssl");
         println!("cargo:rustc-link-lib=dylib=wintun")
     }
 
@@ -82,24 +85,17 @@ fn main() {
         println!("cargo:rustc-link-search=/usr/local/lib");
         println!("cargo:rustc-link-search=/usr/lib");
         println!("cargo:rustc-link-search=/usr/lib/x86_64-linux-gnu");
-        // TODO: for stdc++, optimize auto search
-        println!("cargo:rustc-link-search=/usr/lib/gcc/x86_64-linux-gnu/11");
-
-        // link for openssl
-        println!("cargo:rustc-link-lib=static=crypto");
-        println!("cargo:rustc-link-lib=static=ssl");
-
-        // link for xml2
-        println!("cargo:rustc-link-lib=static=xml2");
-        println!("cargo:rustc-link-lib=static=z");
-        println!("cargo:rustc-link-lib=static=lzma");
-        println!("cargo:rustc-link-lib=static=lz4");
-        println!("cargo:rustc-link-lib=static=icui18n");
-        println!("cargo:rustc-link-lib=static=icudata");
-        println!("cargo:rustc-link-lib=static=icuuc");
-
-        // link for stdc++
-        println!("cargo:rustc-link-lib=static=stdc++");
+        println!("cargo:rustc-link-search=/lib/x86_64-linux-gnu");
+        println!("cargo:rustc-link-lib=dylib=crypto");
+        println!("cargo:rustc-link-lib=dylib=ssl");
+        println!("cargo:rustc-link-lib=dylib=xml2");
+        println!("cargo:rustc-link-lib=dylib=z");
+        println!("cargo:rustc-link-lib=dylib=lzma");
+        link_linux_system_lib("lz4");
+        link_linux_system_lib("icui18n");
+        link_linux_system_lib("icudata");
+        link_linux_system_lib("icuuc");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 
     #[cfg(target_os = "macos")]
@@ -138,7 +134,7 @@ fn main() {
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let mut bindings_builder = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
@@ -148,8 +144,30 @@ fn main() {
         .trust_clang_mangling(true)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        // Finish the builder and generate the bindings.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(output) = std::process::Command::new("gcc")
+            .arg("-print-file-name=include")
+            .output()
+        {
+            if output.status.success() {
+                if let Ok(path) = String::from_utf8(output.stdout) {
+                    let path = path.trim();
+                    if !path.is_empty() {
+                        bindings_builder = bindings_builder.clang_arg(format!("-I{path}"));
+                    }
+                }
+            }
+        }
+        for include in ["/usr/include", "/usr/include/x86_64-linux-gnu"] {
+            bindings_builder = bindings_builder.clang_arg(format!("-I{include}"));
+        }
+    }
+
+    // Finish the builder and generate the bindings.
+    let bindings = bindings_builder
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
@@ -167,4 +185,36 @@ fn main() {
             }
         )))
         .expect("Couldn't write bindings!");
+}
+
+#[cfg(target_os = "linux")]
+fn link_linux_system_lib(name: &str) {
+    let search_dirs = ["/usr/lib/x86_64-linux-gnu", "/lib/x86_64-linux-gnu"];
+    for dir in search_dirs {
+        let plain = PathBuf::from(dir).join(format!("lib{name}.so"));
+        if plain.exists() {
+            println!("cargo:rustc-link-lib=dylib={name}");
+            return;
+        }
+    }
+
+    for dir in search_dirs {
+        if let Ok(entries) = fs::read_dir(dir) {
+            let prefix = format!("lib{name}.so.");
+            let mut candidates: Vec<String> = entries
+                .filter_map(Result::ok)
+                .filter_map(|entry| entry.file_name().into_string().ok())
+                .filter(|file| file.starts_with(&prefix))
+                .collect();
+            candidates.sort();
+            if let Some(best) = candidates.last() {
+                println!("cargo:rustc-link-search={dir}");
+                println!("cargo:rustc-link-lib=dylib:+verbatim={best}");
+                return;
+            }
+        }
+    }
+
+    println!("cargo:warning=Could not locate shared library for {name}");
+    println!("cargo:rustc-link-lib=dylib={name}");
 }


### PR DESCRIPTION
On my machine (a vanilla Ubuntu 25.10 install) the build system fails for various reasons, including static libraries not being available, and include directories not being found. Fix the build on my machine with a few toward making it generally more robust.